### PR TITLE
don't ignor --folder when source is not URL

### DIFF
--- a/log_extractor/extractor.py
+++ b/log_extractor/extractor.py
@@ -545,7 +545,6 @@ def run(source, folder, logs, team, log_output, verbose):
         source = source_path
 
     if source_type == "dir":
-        folder = source
         source_object = DirNode(source_path)
     elif source_type == "zip":
         folder = os.path.dirname(source)


### PR DESCRIPTION
currently --folder is taken into consideration only when sourc
e type is URL, however we want also to be able to set the output
folder also when source type is not URL