### PR TITLE
ignore lines that shouldn't be parsed

### DIFF
--- a/log_extractor/constants.py
+++ b/log_extractor/constants.py
@@ -40,3 +40,5 @@ HOST_LOGS_SPEC = "hypervisor"
 DEFAULT_LOGS = HOST_LOGS + [ENGINE_LOG]
 
 TEMPDIR_NAME = "tempdir"
+
+LINES_TO_IGNORE = ('reportportal_client',)

--- a/log_extractor/extractor.py
+++ b/log_extractor/extractor.py
@@ -303,6 +303,9 @@ class LogExtractor(object):
             with source_object.open(art_runner_file) as f:
                 for line in f:
                     setup_line = any(s in line for s in const.FIELDS_SETUP)
+                    ignore_line = any(s in line for s in const.LINES_TO_IGNORE)
+                    if ignore_line:
+                        continue
                     if setup_line:
                         ts = self._get_art_log_ts(line=line)
                         start_write = True


### PR DESCRIPTION
currently log-extractor tries to parse line which it shouldn't
which cause creation of folders which are not tests.
At the moment the bad line are lines coming from report portal
client plugin.